### PR TITLE
Fix failing test

### DIFF
--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -264,7 +264,7 @@ class PhakeTest extends PHPUnit_Framework_TestCase
 	{
 		$mock = Phake::mock('PhakeTest_MockedClass');
 
-		Phake::when($mock)->fooWithArgument(equalTo('bar'))->thenReturn(42);
+		Phake::when($mock)->fooWithArgument($this->equalTo('bar'))->thenReturn(42);
 
 		$this->assertEquals(42, $mock->fooWithArgument('bar'));
 		$this->assertNull($mock->fooWithArgument('test'));
@@ -782,17 +782,17 @@ class PhakeTest extends PHPUnit_Framework_TestCase
 
 		Phake::verify($mock, Phake::times(6))->fooWithLotsOfParameters(Phake::anyParameters());
 	}
-	
+
 	/**
 	 * Tests that when stubs are defined, they're matched in reverse order.
 	 */
 	public function testMatchesInReverseOrder()
 	{
 		$mock = Phake::mock('PhakeTest_MockedClass');
-		
+
 		Phake::when($mock)->fooWithArgument($this->anything())->thenReturn(FALSE);
 		Phake::when($mock)->fooWithArgument('foo')->thenReturn(TRUE);
-		
+
 		$this->assertTrue($mock->fooWithArgument('foo'));
 	}
 


### PR DESCRIPTION
testStubWithHamcrestConstraint is missing a $this for the equalTo check

This commit just adds that in

Before:
PHPUnit 3.5.6 by Sebastian Bergmann.

..........SS...
Fatal error: Call to undefined function equalTo() in /git/Phake/tests/PhakeTest.php on line 267

After:
PHPUnit 3.5.6 by Sebastian Bergmann.

..........SS.............................................

Time: 1 second, Memory: 15.25Mb

OK, but incomplete or skipped tests!
Tests: 57, Assertions: 52, Skipped: 2.

Generating code coverage report, this may take a moment.
