### PR TITLE
Adding Phake_Stubber_Answers_LambdaAnswer

### DIFF
--- a/src/Phake/Proxies/AnswerBinderProxy.php
+++ b/src/Phake/Proxies/AnswerBinderProxy.php
@@ -45,6 +45,7 @@
 require_once 'Phake/Stubber/Answers/StaticAnswer.php';
 require_once 'Phake/Stubber/Answers/ParentDelegate.php';
 require_once 'Phake/Stubber/Answers/ExceptionAnswer.php';
+require_once 'Phake/Stubber/Answers/LambdaAnswer.php';
 
 /**
  * A proxy class to provide a fluent interface into the answer binder.
@@ -71,6 +72,17 @@ class Phake_Proxies_AnswerBinderProxy
 	public function thenReturn($value)
 	{
 		return $this->binder->bindAnswer(new Phake_Stubber_Answers_StaticAnswer($value));
+	}
+	
+	/**
+	 * Binds a Lambda answer to the method
+	 */
+	public function thenGetReturnByLambda($value)
+	{
+		if (!is_callable($value))
+			throw new InvalidArgumentException("Given lambda is not callable");
+			
+		return $this->binder->bindAnswer(new Phake_Stubber_Answers_LambdaAnswer($value));
 	}
 
 	/**

--- a/src/Phake/Stubber/Answers/LambdaAnswer.php
+++ b/src/Phake/Stubber/Answers/LambdaAnswer.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once 'Phake/Stubber/IAnswer.php';
+
+/**
+ * Allows providing a static answer to a stubbed method call.
+ *
+ * @author Mathieu Kooiman <mathieuk@gmail.com>
+ */
+class Phake_Stubber_Answers_LambdaAnswer implements Phake_Stubber_Answers_IDelegator, Phake_Stubber_IAnswerDelegate
+{
+	/**
+	 * @var mixed
+	 */
+	private $answerLambda;
+
+	/**
+	 * @param mixed $answer
+	 */
+	public function __construct($answerLambda)
+	{
+		$this->answerLambda = $answerLambda;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getAnswer()
+	{
+		return $this;		
+	}
+	
+	/**
+	 * Actually calls the given lambda to produce the answer
+	 * @return mixed 
+  	 */
+	public function getActualAnswer()
+	{	
+		$lambda = $this->answerLambda;
+		return call_user_func_array($lambda, func_get_args());
+	}
+	
+	/**
+	 * Return callback to produce actual answer
+	 *
+	 * @param object $calledObject
+	 * @param string $calledMethod
+	 * @param array $calledParameters
+	 * @return array callback
+	 */
+	public function getCallBack($calledObject, $calledMethod, array $calledParameters)
+	{
+		return array($this, 'getActualAnswer');
+	}
+
+	/**
+	 * Passes through the given arguments.
+	 * @param string $calledMethod
+	 * @param array $calledParameters
+	 */
+	public function getArguments($calledMethod, array $calledParameters)
+	{
+		return $calledParameters;
+	}
+	
+	/**
+	 * Nothing to process
+	 * @param mixed $answer
+	 * @return null
+	 */
+	public function processAnswer($answer)
+	{
+	}
+}
+
+?>

--- a/tests/Phake/Proxies/AnswerBinderProxyTest.php
+++ b/tests/Phake/Proxies/AnswerBinderProxyTest.php
@@ -87,7 +87,34 @@ class Phake_Proxies_AnswerBinderProxyTest extends PHPUnit_Framework_TestCase
 
 		$this->assertSame($this->binder, $this->proxy->thenReturn(42));
 	}
+	
+	/**
+	 * Tests the thenGetReturnByLambda functionality of the proxy
+	 *
+	 * It should result in the binder being called with a lambda answer
+	 */
+	public function testThenGetReturnByLambda()
+	{
+		$func = create_function('$arg1', 'return $arg1;');
+		
+		$this->binder->expects($this->once())
+				->method('bindAnswer')
+				->with($this->logicalAnd($this->isInstanceOf('Phake_Stubber_Answers_LambdaAnswer'), $this->attributeEqualTo('answerLambda', $func)))
+				->will($this->returnValue($this->binder));
 
+		$this->assertSame($this->binder, $this->proxy->thenGetReturnByLambda($func));	
+	}
+	
+	/**
+	 * Tests that thenGetReturnByLambda throws an exception if the given lambda is not callable
+	 */
+	public function testThenGetReturnByLambdaThrowsExceptionForUncallableLambda()
+	{
+		$this->setExpectedException('InvalidArgumentException');
+        
+		$func = 'some_unknown_function';
+		$this->proxy->thenGetReturnByLambda($func);
+	}
 	/**
 	 * Tests the thenCallParent functionality of the proxy
 	 */

--- a/tests/Phake/Stubber/Answers/LambdaAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/LambdaAnswerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once 'Phake/Stubber/Answers/LambdaAnswer.php';
+
+class Phake_Stubber_Answers_LambdaAnswerTest extends PHPUnit_Framework_TestCase
+{
+	private $_answer;
+	
+	public function testLambdaAnswerAcceptsOldschoolLambda()
+	{			
+		$func   = create_function('$arg1', 'return $arg1;');
+		$answer = new Phake_Stubber_Answers_LambdaAnswer($func);
+		
+		$callback = $answer->getCallback($this, 'foo', array('bar'));
+		
+		$result = call_user_func_array($callback, array('bar'));
+		$this->assertSame("bar", $result);
+	}
+}


### PR DESCRIPTION
When trying to write unit tests that ultimately deal with my database class, I wound up adding a lot of boilerplate code to just get the thing to run, for instance: 

```
    // setup
    Phake::when($this->_mock_db)
        ->sql_columns_from_array_for_where(Phake::equalTo($identifier_data))
        ->thenReturn(array("customer_id = 1234"));

    Phake::when($this->_mock_db)->sql_escapestring('1234')->thenReturn(1234);
    Phake::when($this->_mock_db)->sql_escapestring('key')->thenReturn('key');
    Phake::when($this->_mock_db)->sql_escapestring('value')->thenReturn('value');
```

The mocked calls to sql_escapestring are not actually of interest for this test, they just need to be there to be able to determine a proper call to another method is made later on:

```
Phake::verify($this->_mock_db)
        ->sql_query(Phake::equalTo("REPLACE INTO customer_settings (customer_id,name,value) VALUES ('1234', 'key', 'value')")); 
```

To make this a bit easier and less fragile, I've added the LambaAnswer to Phake with this commit:

```
Phake::when($mock) 
    ->sql_escapestring(Phake::anyParameters())
    ->thenGetReturnByLambda(function($arg1) { return addslashes($arg1); }); // use addslashes instead of mysql_real_escape_string to prevent needing a db connection

echo $mock->sql_escapestring('te\'st'); // te\'st
```

The added code does not depend on any PHP 5.3 specific code and as such, even oldschool lambda's created with create_function() can be used. 
