### PR TITLE
Fixed issue #25.

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -388,6 +388,9 @@ class {$newClassName} {$extends}
 	 */
 	protected function implementParameter(ReflectionParameter $parameter)
 	{
+		$default = '';
+		$type = '';
+		
 		if ($parameter->isArray())
 		{
 			$type = 'array ';
@@ -396,18 +399,14 @@ class {$newClassName} {$extends}
 		{
 			$type = $parameter->getClass()->getName() . ' ';
 		}
-		else
-		{
-			$type = '';
-		}
 
 		if ($parameter->isDefaultValueAvailable())
 		{
 			$default = ' = ' . var_export($parameter->getDefaultValue(), TRUE);
 		}
-		else
+		elseif ($parameter->isOptional())
 		{
-			$default = '';
+			$default = ' = null';
 		}
 
 		return $type . ($parameter->isPassedByReference() ? '&' : '') . '$parm' . $parameter->getPosition() . $default;

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1000,6 +1000,13 @@ class PhakeTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('magicCalled', $mock->magicCall());
 		$this->assertEquals($expected, $mock->unStubbedCall());
 	}
+	
+	public function testMockingSoapClient()
+	{
+		// This test requires that E_STRICT be on
+		// It will fail with it on, otherwise it wont' complain
+		Phake::mock('SoapClient');
+	}
 }
 
 ?>


### PR DESCRIPTION
Fixed problem with setting mocked method parameters where it wouldn't check for optional parameters. This fixes issue #25 where SoapClient couldn't be mocked without getting an E_STRICT error for not matching the overrided __soapCall() method.
