### PR TITLE
Caching for previously defined mock classes

### DIFF
--- a/src/Phake/Facade.php
+++ b/src/Phake/Facade.php
@@ -52,6 +52,13 @@ require_once 'Phake/Stubber/StubMapper.php';
  */
 class Phake_Facade
 {
+	private $cachedClasses;
+	
+	public function __construct()
+	{
+	  $this->cachedClasses = array();
+	}
+	
 	/**
 	 * Creates a new mock class than can be stubbed and verified.
 	 *
@@ -67,10 +74,16 @@ class Phake_Facade
 		{
 			throw new InvalidArgumentException("The class / interface [{$mockedClass} does not exist");
 		}
-
-		$newClassName = $this->generateUniqueClassName($mockedClass);
-		$mockGenerator->generate($newClassName, $mockedClass);
-		return $mockGenerator->instantiate($newClassName, $callRecorder, new Phake_Stubber_StubMapper(), $defaultAnswer, $constructorArgs);
+		
+    if(!isset($this->cachedClasses[$mockedClass]))
+    {
+      $newClassName = $this->generateUniqueClassName($mockedClass);
+      $mockGenerator->generate($newClassName, $mockedClass);
+ 
+      $this->cachedClasses[$mockedClass] = $newClassName;
+    }
+       
+    return $mockGenerator->instantiate($this->cachedClasses[$mockedClass], $callRecorder, new Phake_Stubber_StubMapper(), $defaultAnswer, $constructorArgs);
 	}
 
 	/**


### PR DESCRIPTION
First of all, I just recently started using Phake and it's been a breeze to use thus far.  So thank you!

As I've been adding more and more mocks to my tests, I noticed my memory usage getting pretty bloated (339 tests, and ~447Mb or memory)  After running some tests, I traced a part of the problem to Phake_Facade::mock(), which was generating a whole new class definition each time a mock was created.

My patch just caches the names of all mock classes by their original class names, and that seems to have made my tests run with 1/5 of the memory it used to (339 tests using ~87Mb of memory.)  I haven't gotten a chance to dig too deeply into all of the code, so this may not be the best way to solve this particular issue, but I wanted to throw this out there and get some feedback to see if this as a path worth going down.

Thanks!
