### PR TITLE
Added support for PHPUnit 3.6.

### DIFF
--- a/src/Phake/Matchers/PHPUnitConstraintAdapter.php
+++ b/src/Phake/Matchers/PHPUnitConstraintAdapter.php
@@ -73,7 +73,7 @@ class Phake_Matchers_PHPUnitConstraintAdapter implements Phake_Matchers_IArgumen
 	 */
 	public function matches(&$argument)
 	{
-		return $this->constraint->evaluate($argument);
+		return $this->constraint->evaluate($argument, '', true);
 	}
 
 	public function __toString()


### PR DESCRIPTION
Backward Compatibility broken with PHPUnit 3.6. The new signature of the PHPUnit_Framework_Constraint::evaluate() does not work with Phake.

Here is two version of the evaluate() method:
- abstract public function evaluate($other);
- public function evaluate($other, $description = '', $returnResult = FALSE)
