### PR TITLE
Mock __destruct()

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -117,6 +117,8 @@ class {$newClassName} {$extends}
 			
 		{$this->getConstructorChaining($mockedClass)}
 	}
+	
+	public function __destruct() {}
 
 	{$this->generateMockedMethods($mockedClass)}
 }

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -56,6 +56,7 @@ require_once 'PhakeTest/MockedConstructedClass.php';
 require_once 'PhakeTest/MockedInterface.php';
 require_once 'PhakeTest/FinalMethod.php';
 require_once 'PhakeTest/ToStringMethod.php';
+require_once 'PhakeTest/DestructorClass.php';
 
 /**
  * Description of MockClass
@@ -541,6 +542,21 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
 
 		$this->assertNotNull($string, '__toString() should not return NULL');
 		$this->assertEquals('Mock for PhakeTest_ToStringMethod', $string);
+	}
+	
+	public function testDestructMocked()
+	{
+		$mock = $newClassName = __CLASS__ . '_TestClass' . uniqid();
+		$mockedClass = 'PhakeTest_DestructorClass';
+		$this->classGen->generate($newClassName, $mockedClass);
+		
+		$recorder = $this->getMock('Phake_CallRecorder_Recorder');
+		$mapper = new Phake_Stubber_StubMapper();
+		$answer = new Phake_Stubber_Answers_ParentDelegate();
+		
+		$mock = $this->classGen->instantiate($newClassName, $recorder, $mapper, $answer);
+		
+		unset($mock);
 	}
 }
 

--- a/tests/PhakeTest/DestructorClass.php
+++ b/tests/PhakeTest/DestructorClass.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2011, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+require_once 'PhakeTest/MockedInterface.php';
+
+class PhakeTest_DestructorClass
+{
+	public function __destruct()
+	{
+		trigger_error('destruct should not be called');
+	}
+}


### PR DESCRIPTION
I would guess we should be mocking __destruct(), since there are classes that can do weird things with it. (Like throw PHP warnings)
