### PR TITLE
Fix for PHPUnit 3.6 compatibility

### DIFF
--- a/src/Phake/PHPUnit/VerifierResultConstraint.php
+++ b/src/Phake/PHPUnit/VerifierResultConstraint.php
@@ -48,7 +48,7 @@
  */
 class Phake_PHPUnit_VerifierResultConstraint extends PHPUnit_Framework_Constraint
 {
-	public function evaluate($other) 
+	public function matches($other)
 	{
 		if (!$other instanceof Phake_CallRecorder_VerifierResult)
 		{
@@ -62,14 +62,17 @@ class Phake_PHPUnit_VerifierResultConstraint extends PHPUnit_Framework_Constrain
 		return 'is called';
 	}
 
-	protected function customFailureDescription($other, $description, $not)
+	protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
 	{
 		if (!$other instanceof Phake_CallRecorder_VerifierResult)
 		{
 			throw new InvalidArgumentException("You must pass an instance of Phake_CallRecorder_VerifierResult");
 		}
 
-		return $other->getFailureDescription();
+		throw new PHPUnit_Framework_ExpectationFailedException(
+			$other->getFailureDescription(),
+			$comparisonFailure
+		);
 	}
 }
 ?>

--- a/tests/Phake/PHPUnit/VerifierResultConstraintTest.php
+++ b/tests/Phake/PHPUnit/VerifierResultConstraintTest.php
@@ -63,13 +63,13 @@ class Phake_PHPUnit_VerifierResultConstraintTest extends PHPUnit_Framework_TestC
 	public function testEvaluateReturnsTrueIfVerifyResultIsTrue()
 	{
 		$result = new Phake_CallRecorder_VerifierResult(TRUE, array());
-		$this->assertTrue($this->constraint->evaluate($result));
+		$this->assertTrue($this->constraint->evaluate($result, '', TRUE));
 	}
 	
 	public function testEvaluateReturnsFalseWhenVerifierReturnsFalse()
 	{
 		$result = new Phake_CallRecorder_VerifierResult(FALSE, array());
-		$this->assertFalse($this->constraint->evaluate($result));
+		$this->assertFalse($this->constraint->evaluate($result, '', TRUE));
 	}
 	
 	/**
@@ -88,15 +88,19 @@ class Phake_PHPUnit_VerifierResultConstraintTest extends PHPUnit_Framework_TestC
 	public function testCustomFailureDescriptionReturnsDescriptionFromResult()
 	{
 		$result = new Phake_CallRecorder_VerifierResult(FALSE, array(), "The call failed!");
+
+		$reflector = new ReflectionObject($this->constraint);
+		$method = $reflector->getMethod('fail');
+		$method->setAccessible(TRUE);
 		
 		try
 		{
-			$this->constraint->fail($result, '');
+			$method->invoke($this->constraint, $result, '');
 			$this->fail('expected an exception to be thrown');
 		}
 		catch (PHPUnit_Framework_ExpectationFailedException $e)
 		{
-			$this->assertEquals('The call failed!', $e->getDescription());
+			$this->assertEquals('The call failed!', $e->getMessage());
 		}
 	}
 	
@@ -105,7 +109,11 @@ class Phake_PHPUnit_VerifierResultConstraintTest extends PHPUnit_Framework_TestC
 	 */
 	public function testFailThrowsWhenArgumentIsNotAResult()
 	{
-		$this->constraint->fail('', '');
+		$reflector = new ReflectionObject($this->constraint);
+		$method = $reflector->getMethod('fail');
+		$method->setAccessible(TRUE);
+
+		$method->invoke($this->constraint, '', '');
 	}
 }
 ?>


### PR DESCRIPTION
I don't expect you'll want to pull this immediately, as it probably breaks compatibility with earlier versions of PHPUnit, _BUT_ please note that Phake's verification is completely broken under PHPUnit 3.6 without these changes.

By that, I mean that even when verification fails, it is not reported in PHPUnit's output at all. This is obviously a pretty big issue for those who want to upgrade to PHPUnit 3.6.
