### PR TITLE
Fixing "Fatal error: Nesting level too deep - recursive dependency?"

### DIFF
--- a/src/Phake/CallRecorder/Recorder.php
+++ b/src/Phake/CallRecorder/Recorder.php
@@ -108,7 +108,7 @@ class Phake_CallRecorder_Recorder
 	 */
 	public function getCallInfo(Phake_CallRecorder_Call $call)
 	{
-		if (in_array($call, $this->calls))
+		if (in_array($call, $this->calls, true))
 		{
 			return new Phake_CallRecorder_CallInfo($call, $this->positions[spl_object_hash($call)]);
 		}


### PR DESCRIPTION
Sometimes an error **Fatal error: Nesting level too deep - recursive dependency? ...** is raised when verifying an object with circular dependency.

```
PHPUnit 3.6.4 by Sebastian Bergmann.

.......
Fatal error: Nesting level too deep - recursive dependency? in /home/iteman/site-php/PEAR/Phake/CallRecorder/Recorder.php on line 111
```
