### PR TITLE
Move PHPUnit setup examples to correct files. 

### DIFF
--- a/docs/docbook/configuration/setting-client.xml
+++ b/docs/docbook/configuration/setting-client.xml
@@ -3,7 +3,6 @@
 	<title>Setting the Phake Client</title>
 		<programlisting><![CDATA[<?php
 require_once('Phake.php');
-require_once('Phake/ClassGenerator/FileLoader.php');
-Phake::setMockLoader(new Phake_ClassGenerator_FileLoader('/tmp'));
+Phake::setClient(Phake::CLIENT_PHPUNIT);
 ?>]]></programlisting>
 </example>

--- a/docs/docbook/configuration/setting-loader.xml
+++ b/docs/docbook/configuration/setting-loader.xml
@@ -3,6 +3,7 @@
 	<title>Setting the Mock Class Loader</title>
 		<programlisting><![CDATA[<?php
 require_once('Phake.php');
-Phake::setLoader(Phake::CLIENT_PHPUNIT);
+require_once('Phake/ClassGenerator/FileLoader.php');
+Phake::setMockLoader(new Phake_ClassGenerator_FileLoader('/tmp'));
 ?>]]></programlisting>
 </example>


### PR DESCRIPTION
Change method call for PHPUnit compability mode (Phake::setLoader => Phake::setClient)

Addresses Issue #55 
