### PR TITLE
Making sure, the require statements, won't b0rk :-)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,6 @@
     },
     "autoload": {
         "classmap": ["src"]
-    }
+    },
+    "include-path": ["src"]
 }


### PR DESCRIPTION
In preparation for issue-61 please add: "include-path" : [ "src" ] to the composer.json. It's deprecated behavior, but it'll make sure that including Phake as library works for the time being, until the requires have been removed.
