### PR TITLE
Bug fix: Phake_Matchers_Factory::createMatcher('Class_Name') bad behavior

### DIFF
--- a/src/Phake/Matchers/Factory.php
+++ b/src/Phake/Matchers/Factory.php
@@ -69,10 +69,6 @@ class Phake_Matchers_Factory
 		{
 			return $argument;
 		}
-		elseif (is_string($argument) && class_exists($argument) && is_subclass_of($argument, 'Phake_Matchers_IArgumentMatcher'))
-		{
-			return new $argument;
-		}
 		elseif (class_exists('PHPUnit_Framework_Constraint')
 				&& $argument instanceof PHPUnit_Framework_Constraint)
 		{

--- a/src/Phake/Proxies/StubberProxy.php
+++ b/src/Phake/Proxies/StubberProxy.php
@@ -103,8 +103,6 @@ class Phake_Proxies_StubberProxy
 	 */
 	public function __get($method)
 	{
-		return $this->__call($method, array('Phake_Matchers_AnyParameters'));
+		return $this->__call($method, array(new Phake_Matchers_AnyParameters));
 	}
 }
-
-?>

--- a/tests/Phake/Matchers/FactoryTest.php
+++ b/tests/Phake/Matchers/FactoryTest.php
@@ -80,29 +80,6 @@ class Phake_Matchers_FactoryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests creating a matcher by name
-	 */
-	public function testMatcherByName ()
-	{
-		$matcher = $this->factory->createMatcher('Phake_Matchers_AnyParameters');
-
-		$this->assertInstanceOf('Phake_Matchers_AnyParameters', $matcher);
-
-		$value = '';
-		$this->assertTrue($matcher->matches($value));
-	}
-
-	/**
-	 * Tests creating a matcher by name fails if the required interface is not implemented
-	 */
-	public function testMatcherByNameMustImplementRequiredInterface ()
-	{
-		$matcher = $this->factory->createMatcher('Phake_Matchers_MethodMatcher');
-
-		$this->assertNotInstanceOf('Phake_Matchers_MethodMatcher', $matcher);
-	}
-
-	/**
 	 * Tests creating a pass through matcher
 	 */
 	public function testPassThroughMatcher()


### PR DESCRIPTION
First off, I'm very sorry. In my previous pull request, I made it possible to initialize class names from Phake_Matchers_Factory::createMatcher(). I thought it would be useful, but it turned out to be buggy. PHP:class_implements() works differently from what I thought, it is actually PHP:is_subclass_of() that should have been used.

I fixed that issue, but coming back to the code a second time I noticed that it's an unneeded feature, so I decided to remove the code from Phake_Matchers_Factory::createMatcher(), basically reverting the changes from the last pull request. 

Please review and merge this if you can. I hope no one's lives are ruined by this bug. Sorry!
