### PR TITLE
Stubs called with default parameters can be verified without specifying ...

### DIFF
--- a/src/Phake/CallRecorder/CallExpectation.php
+++ b/src/Phake/CallRecorder/CallExpectation.php
@@ -93,6 +93,18 @@ class Phake_CallRecorder_CallExpectation
         $this->argumentMatchers = $argumentMatchers;
         $this->verifierMode     = $verificationMode;
         $this->mockReader       = $mockReader;
+
+        if (method_exists($this->object, $this->method)) {
+            $method = new ReflectionMethod($this->object, $this->method);
+
+            if ($method->getNumberOfParameters() !== $method->getNumberOfRequiredParameters()) {
+                foreach ($method->getParameters() as $i => $param) {
+                    if (!isset($this->argumentMatchers[$i]) && $param->isOptional()) {
+                        $this->argumentMatchers[$i] = new Phake_Matchers_EqualsMatcher($param->getDefaultValue());
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -302,10 +302,18 @@ class {$newClassName} {$extends}
         $methodDef = "
 	{$modifiers} function {$reference}{$method->getName()}({$this->generateMethodParameters($method)})
 	{
+		\$funcArgs = get_defined_vars();
+		unset(\$funcArgs['this']);
+
+        if (count(\$funcArgs)) {
+		    \$funcArgs = array_values(\$funcArgs);
+        } else {
+            \$funcArgs = func_get_args();
+        }
+
 		\$args = array();
 		{$this->copyMethodParameters($method)}
-		
-		\$funcArgs = func_get_args();
+
 		\$answer = \$this->__PHAKE_handlerChain->invoke(\$this, '{$method->getName()}', \$funcArgs, \$args);
 		
 		if (\$answer instanceof Phake_Stubber_Answers_IDelegator)
@@ -355,7 +363,7 @@ class {$newClassName} {$extends}
      */
     protected function copyMethodParameters(ReflectionMethod $method)
     {
-        $copies = "\$numArgs = count(func_get_args());\n\t\t";
+        $copies = "\$numArgs = count(\$funcArgs);\n\t\t";
         foreach ($method->getParameters() as $parameter) {
             $pos = $parameter->getPosition();
             $copies .= "if ({$pos} < \$numArgs) \$args[] =& \$parm{$pos};\n\t\t";
@@ -363,7 +371,7 @@ class {$newClassName} {$extends}
 
         $copies .= "for (\$i = " . count(
             $method->getParameters()
-        ) . "; \$i < \$numArgs; \$i++) \$args[] = func_get_arg(\$i);\n\t\t";
+        ) . "; \$i < \$numArgs; \$i++) \$args[] = \$funcArgs[\$i];\n\t\t";
 
         return $copies;
     }

--- a/src/Phake/Matchers/MethodMatcher.php
+++ b/src/Phake/Matchers/MethodMatcher.php
@@ -70,6 +70,30 @@ class Phake_Matchers_MethodMatcher implements Phake_Matchers_IMethodMatcher
     }
 
     /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->expectedMethod;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMatchers()
+    {
+        return $this->argumentMatchers;
+    }
+
+    /**
+     * @param Phake_Matchers_IArgumentMatcher $argumentMatcher
+     */
+    public function addMatcher(Phake_Matchers_IArgumentMatcher $argumentMatcher)
+    {
+        $this->argumentMatchers[] = $argumentMatcher;
+    }
+
+    /**
      * Determines if the given method and arguments match the configured method and argument matchers
      * in this object. Returns true on success, false otherwise.
      *

--- a/src/Phake/Stubber/AnswerBinder.php
+++ b/src/Phake/Stubber/AnswerBinder.php
@@ -76,6 +76,20 @@ class Phake_Stubber_AnswerBinder implements Phake_Stubber_IAnswerBinder
         $this->obj        = $obj;
         $this->matcher    = $matcher;
         $this->mockReader = $mockReader;
+
+        if (method_exists($this->obj, $this->matcher->getMethod())) {
+            $method = new ReflectionMethod($this->obj, $this->matcher->getMethod());
+
+            if ($method->getNumberOfParameters() !== $method->getNumberOfRequiredParameters()) {
+                $argumentMatchers = $this->matcher->getMatchers();
+
+                foreach ($method->getParameters() as $i => $param) {
+                    if (!isset($argumentMatchers[$i]) && $param->isOptional()) {
+                        $this->matcher->addMatcher(new Phake_Matchers_EqualsMatcher($param->getDefaultValue()));
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -215,7 +215,7 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
     /**
      * Tests that default parameters work correctly with stubbing
      */
-    public function testStubbedMethodDoesNotCheckUnpassedDefaultParameters()
+    public function testStubbedMethodPassesDefaultParameters()
     {
         $newClassName = __CLASS__ . '_TestClass23';
         $mockedClass  = 'PhakeTest_MockedClass';
@@ -234,7 +234,7 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
 
         $stubMapper->expects($this->once())
             ->method('getStubByCall')
-            ->with($this->equalTo('fooWithDefault'), array())
+            ->with($this->equalTo('fooWithDefault'), array(null))
             ->will($this->returnValue(new Phake_Stubber_AnswerCollection($answer)));
 
         $mock->fooWithDefault();

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -243,6 +243,24 @@ class PhakeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests passing no matcher to the verify method will correctly verify a call with same-as-default values.
+     */
+    public function testVerifyCallWithEqualsMatcherAndPassingDefaultValues()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+
+        $mock->fooWithDefault(null);
+        $mock->fooWithTwoDefaults(null, null);
+        $mock->fooWithTwoDefaults('non-default', null);
+        $mock->fooWithSecondDefault('required', null);
+
+        Phake::verify($mock)->fooWithDefault();
+        Phake::verify($mock)->fooWithTwoDefaults();
+        Phake::verify($mock)->fooWithTwoDefaults('non-default');
+        Phake::verify($mock)->fooWithSecondDefault('required');
+    }
+
+    /**
      * Tests that we can implicitely indicate an equalTo matcher when we pass in a non-matcher value.
      */
     public function testVerifyCallWithDefaultMatcher()

--- a/tests/PhakeTest/MockedClass.php
+++ b/tests/PhakeTest/MockedClass.php
@@ -57,6 +57,15 @@ class PhakeTest_MockedClass
     {
     }
 
+    public function fooWithTwoDefaults($default1 = null, $default2 = null)
+    {
+    }
+
+    public function fooWithSecondDefault($arg1, $default = null)
+    {
+    }
+
+
     public function fooWithArgument($arg1)
     {
     }


### PR DESCRIPTION
...those parameters.

See https://github.com/mlively/Phake/issues/51.
