### PR TITLE
Phake_Matchers_AnyParameters can now be used as non-first argument match...

### DIFF
--- a/src/Phake/Matchers/MethodMatcher.php
+++ b/src/Phake/Matchers/MethodMatcher.php
@@ -134,10 +134,6 @@ class Phake_Matchers_MethodMatcher implements Phake_Matchers_IMethodMatcher
         foreach ($args as $i => &$arg) {
             $matcher = $this->argumentMatchers[$i];
 
-            if (!$matcher->matches($arg)) {
-                return false;
-            }
-
             /**
              * AnyParameters matcher found, so match arguments in reverse order
              */
@@ -158,6 +154,10 @@ class Phake_Matchers_MethodMatcher implements Phake_Matchers_IMethodMatcher
                 }
 
                 return true;
+            }
+
+            if (!$matcher->matches($arg)) {
+                return false;
             }
         }
 

--- a/tests/Phake/Matchers/MethodMatcherTest.php
+++ b/tests/Phake/Matchers/MethodMatcherTest.php
@@ -179,7 +179,7 @@ class PHake_Matchers_MethodMatcherTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($matcher->matches('method', $arguments));
     }
 
-    public function testAnyParameterMatchingInBetweenArgumentsOnly()
+    public function testAnyParameterMatchingInBetweenArguments()
     {
         $matcher = new Phake_Matchers_MethodMatcher('method', array(new Phake_Matchers_EqualsMatcher(1), new Phake_Matchers_AnyParameters(), new Phake_Matchers_EqualsMatcher(3)));
 

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -362,6 +362,21 @@ class PhakeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests using an anyParameters argument matcher between two equalTo matchers with a method stub
+     */
+    public function testStubWithAnyParametersMatcherInBetweenArguments()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+
+        Phake::when($mock)->fooWithArgument(Phake::equalTo('bar'), Phake::anyParameters(), Phake::equalTo('cake'))->thenReturn(42);
+
+        $this->assertEquals(42, $mock->fooWithArgument('bar', 'cake'));
+        $this->assertEquals(42, $mock->fooWithArgument('bar', 'anything', 'cake'));
+        $this->assertNull($mock->fooWithArgument('bar'));
+        $this->assertNull($mock->fooWithArgument('cake'));
+    }
+
+    /**
      * Tests using an anyParameters argument matcher before an equalTo matcher with a method stub
      */
     public function testStubWithAnyParametersMatcherLeadingArgumentsOnly()
@@ -376,7 +391,7 @@ class PhakeTest extends PHPUnit_Framework_TestCase
         $this->assertNull($mock->fooWithArgument('anything', 'not-bar'));
     }
 
-    /**
+     /**
      * Tests using an implicit equalTo argument matcher with a method stub
      */
     public function testStubWithDefaultMatcher()
@@ -1077,7 +1092,7 @@ class PhakeTest extends PHPUnit_Framework_TestCase
     /**
      * Tests that Phake::anyParameters() matches in-between arguments only
      */
-    public function testAnyParametersMatchesInBetweenArgumentsOnly()
+    public function testAnyParametersMatchesInBetweenArguments()
     {
         $mock = Phake::mock('PhakeTest_MockedClass');
 


### PR DESCRIPTION
...er. It will only match the argument at, or the arguments after, its own position in the argument matcher list.

See https://github.com/mlively/Phake/issues/51
