### PR TITLE
Add Phake::reportUnusedStubs() that verifies all stubs are called at least once.

### DIFF
--- a/src/Phake/Facade.php
+++ b/src/Phake/Facade.php
@@ -49,12 +49,15 @@
  */
 class Phake_Facade
 {
-    private $cachedClasses;
+    /**
+     * @var array|string[]
+     */
+    private $cachedClasses = array();
 
-    public function __construct()
-    {
-        $this->cachedClasses = array();
-    }
+    /**
+     * @var array|Phake_IMock[]
+     */
+    private $generatedMocks = array();
 
     /**
      * Creates a new mock class than can be stubbed and verified.
@@ -86,7 +89,7 @@ class Phake_Facade
             $this->cachedClasses[$mockedClass] = $newClassName;
         }
 
-        return $mockGenerator->instantiate(
+        return $this->generatedMocks[] = $mockGenerator->instantiate(
             $this->cachedClasses[$mockedClass],
             $callRecorder,
             new Phake_Stubber_StubMapper(),
@@ -116,5 +119,13 @@ class Phake_Facade
         }
 
         return $base_class_name;
+    }
+
+    /**
+     * @return array|Phake_IMock[]
+     */
+    public function getGeneratedMocks()
+    {
+        return $this->generatedMocks;
     }
 }

--- a/src/Phake/Matchers/MethodMatcher.php
+++ b/src/Phake/Matchers/MethodMatcher.php
@@ -70,6 +70,14 @@ class Phake_Matchers_MethodMatcher implements Phake_Matchers_IMethodMatcher
     }
 
     /**
+     * @return string
+     */
+    public function getMethodName()
+    {
+        return $this->expectedMethod;
+    }
+
+    /**
      * Determines if the given method and arguments match the configured method and argument matchers
      * in this object. Returns true on success, false otherwise.
      *

--- a/src/Phake/Stubber/StubMapper.php
+++ b/src/Phake/Stubber/StubMapper.php
@@ -50,7 +50,7 @@
 class Phake_Stubber_StubMapper
 {
     /**
-     * @var array
+     * @var array[]
      */
     private $matcherStubMap = array();
 
@@ -87,6 +87,16 @@ class Phake_Stubber_StubMapper
         }
 
         return null;
+    }
+
+    /**
+     * Returns the stub map.
+     *
+     * @return array[]
+     */
+    public function getStubMap()
+    {
+        return $this->matcherStubMap;
     }
 
     /**

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -54,11 +54,12 @@ class PhakeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         Phake::setClient(Phake::CLIENT_DEFAULT);
+        Phake::setPhake(new Phake_Facade);
     }
 
     protected function tearDown()
     {
-        Phake::setClient(Phake::CLIENT_DEFAULT);
+        Phake::reportUnusedStubs();
     }
 
     /**
@@ -974,6 +975,27 @@ class PhakeTest extends PHPUnit_Framework_TestCase
         $mock->foo();
         $mock->foo();
         Phake::verify($mock, Phake::atMost(1))->foo();
+    }
+
+    /**
+     * Tests verify any stubs at least once
+     */
+    public function testReportUnusedStubs()
+    {
+        $mock = Phake::mock('PhakeTest_MockedClass');
+        Phake::when($mock)->foo->thenReturn(true);
+
+        try
+        {
+            Phake::reportUnusedStubs();
+        }
+        catch (Phake_Exception_VerificationException $e)
+        {
+            $this->assertContains('Expected PhakeTest_MockedClass->foo(<any parameters>) to be called at least <1> times, actually called <0> times.', $e->getMessage());
+        }
+
+        $mock->foo();
+        // No exception now
     }
 
     /**


### PR DESCRIPTION
This change can report stubs that are defined, but never actually called in the test case. It basically loops through all mock objects and stubs, and calls verifyAtLeastOnce on them.

Feedback is appreciated!
