### PR TITLE
Added support for 'callable' type hint available in PHP 5.4

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -385,6 +385,8 @@ class {$newClassName} {$extends}
 
         if ($parameter->isArray()) {
             $type = 'array ';
+        } elseif (method_exists($parameter, 'isCallable') && $parameter->isCallable()) {
+            $type = 'callable ';
         } elseif ($parameter->getClass() !== null) {
             $type = $parameter->getClass()->getName() . ' ';
         }

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -580,6 +580,19 @@ class Phake_ClassGenerator_MockClassTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('PhakeTest_TraversableInterface', Phake::mock('PhakeTest_TraversableInterface'));
     }
+
+    /**
+     * Ensure that 'callable' type hints in method parameters are supported.
+     */
+    public function testCallableTypeHint ()
+    {
+        if (!version_compare(PHP_VERSION, '5.4', '>='))
+        {
+            $this->markTestSkipped('callable typehint require PHP 5.4');
+        }
+
+        $this->assertInstanceOf('PhakeTest_CallableTypehint', Phake::mock('PhakeTest_CallableTypehint'));
+    }
 }
 
 

--- a/tests/PhakeTest/CallableTypehint.php
+++ b/tests/PhakeTest/CallableTypehint.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2012, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Alexander Metzner <halimath.wilanthaou@gmail.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class PhakeTest_CallableTypehint {
+
+    public function method(callable $callback)
+    {
+    }
+}


### PR DESCRIPTION
Hi,

I modified the class Phake_ClassGenerator_MockClass to support the 'callable' type hint in method parameters.

I also added a unit test (which will be skipped in PHP 5.3) for this behavior. 

Travis build is passing (https://travis-ci.org/halimath/Phake).

Best,
Alex
