### PR TITLE
Remove interface_exists() and class_exists() calls

### DIFF
--- a/src/Phake/Matchers/Factory.php
+++ b/src/Phake/Matchers/Factory.php
@@ -64,13 +64,9 @@ class Phake_Matchers_Factory
     {
         if ($argument instanceof Phake_Matchers_IArgumentMatcher) {
             return $argument;
-        } elseif (class_exists('PHPUnit_Framework_Constraint')
-            && $argument instanceof PHPUnit_Framework_Constraint
-        ) {
+        } elseif ($argument instanceof PHPUnit_Framework_Constraint) {
             return new Phake_Matchers_PHPUnitConstraintAdapter($argument);
-        } elseif (interface_exists('Hamcrest_Matcher')
-            && $argument instanceof Hamcrest_Matcher
-        ) {
+        } elseif ($argument instanceof Hamcrest_Matcher) {
             return new Phake_Matchers_HamcrestMatcherAdapter($argument);
         } else {
             return new Phake_Matchers_EqualsMatcher($argument);


### PR DESCRIPTION
The calls to interface_exists() and class_exists() are unnecessary. They just force calling the autoloader, which can be expensive. In order to use instanceof, it is not necessary to check if the class exists. If the class does not exist in memory, the $argument can never be a sub class of said class.
