### PR TITLE
Fix mocked class with __wakeup() from throwing error.

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -314,6 +314,10 @@ class {$newClassName} {$extends}
 	{
 		\$args = array();
 		{$this->copyMethodParameters($method)}
+
+		if (\$this->__PHAKE_handlerChain === null) {
+		    return null;
+		}
 		
 		\$funcArgs = func_get_args();
 		\$answer = \$this->__PHAKE_handlerChain->invoke(\$this, '{$method->getName()}', \$funcArgs, \$args);

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1263,4 +1263,9 @@ class PhakeTest extends PHPUnit_Framework_TestCase
         // Generated a fatal error before fixed
         $this->assertInstanceOf('Phake_IMock', Phake::mock('PhakeTest_ConstructorInterface'));
     }
+
+    public function testClassWithWakeupWorks()
+    {
+        $this->assertInstanceOf('Phake_IMock', Phake::mock('PhakeTest_WakeupClass'));
+    }
 }

--- a/tests/PhakeTest/WakeupClass.php
+++ b/tests/PhakeTest/WakeupClass.php
@@ -1,0 +1,9 @@
+<?php
+
+class PhakeTest_WakeupClass
+{
+    public function __wakeup()
+    {
+        // do something fun
+    }
+}


### PR DESCRIPTION
When a __wakeup() method is defined for a class that is being mocked, it will be called and our mocked method will attempt to invoke the answer handler chain, which hasn't been set yet, and causes an "invoke() on a non-object".
