### PR TITLE
PDOStatement mocking was not working

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -176,9 +176,9 @@ class {$newClassName} {$extends}
 	public \$__PHAKE_defaultAnswer;
 
 	public \$__PHAKE_isFrozen;
-	
+
 	public \$__PHAKE_name;
-	
+
 	public \$__PHAKE_handlerChain;
 
 	public function __destruct() {}
@@ -213,7 +213,11 @@ class {$newClassName} {$extends}
         Phake_Stubber_IAnswer $defaultAnswer,
         array $constructorArgs = null
     ) {
-        $mockObject = unserialize(sprintf('O:%d:"%s":0:{}', strlen($newClassName), $newClassName));
+        try {
+            $mockObject = unserialize(sprintf('O:%d:"%s":0:{}', strlen($newClassName), $newClassName));
+        } catch (\Exception $e) {
+            $mockObject = new $newClassName();
+        }
 
         $mockObject->__PHAKE_callRecorder = $recorder;
         $mockObject->__PHAKE_stubMapper = $mapper;
@@ -321,7 +325,7 @@ class {$newClassName} {$extends}
 		
 		\$funcArgs = func_get_args();
 		\$answer = \$this->__PHAKE_handlerChain->invoke(\$this, '{$method->getName()}', \$funcArgs, \$args);
-		
+
 		if (\$answer instanceof Phake_Stubber_Answers_IDelegator)
 		{
 			\$delegate = \$answer->getAnswer();

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1268,4 +1268,9 @@ class PhakeTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('Phake_IMock', Phake::mock('PhakeTest_WakeupClass'));
     }
+
+    public function testMockPDOStatement()
+    {
+        $this->assertInstanceOf('PDOStatement', Phake::mock('PDOStatement'));
+    }
 }


### PR DESCRIPTION
When mocking a PDOStatement an exception was thrown:
"PDOException: You cannot serialize or unserialize PDO instances"
This used to work in alpha2 and was broken in alpha3. This is a naive
patch that just catches the exception and uses the old way of creating
the object. I could not duplicate this happening in general with an
exception being thrown in __wakeup() or unserialize(), if implements
Serializable.
