### PR TITLE
Fixed syntax error in answers.rst

### DIFF
--- a/docs/answers.rst
+++ b/docs/answers.rst
@@ -53,7 +53,7 @@ In order to test this we must mock ``foo()`` so that it throws an exception when
             $data = Phake::mock('MyData');
             $processor = Phake::mock('MyDataProcessor');
 
-            Phake::when($processor)->process($data)->thenThrow(new Exception('My error message!');
+            Phake::when($processor)->process($data)->thenThrow(new Exception('My error message!'));
 
             $sut = new MyClass($logger);
             $sut->processSomeData($processor, $data);


### PR DESCRIPTION
"Throwing Exceptions" example was missing a closing parenthesis
