### PR TITLE
Mistyped class name in example

### DIFF
--- a/docs/method-parameter-matchers.rst
+++ b/docs/method-parameter-matchers.rst
@@ -228,6 +228,6 @@ a customer argument matcher it would look something like this.
 
             $cardGame = new MyPokerGame($dealer, $players);
 
-            Phake::verify($dealer)->deal(new 52CardDeckMatcher(), $players);
+            Phake::verify($dealer)->deal(new FiftyTwoCardDeckMatcher(), $players);
         }
     }


### PR DESCRIPTION
In example class name is "FiftyTwoCardDeckMatcher" but latter on new object is created "new 52CardDeckMatcher()"
