### PR TITLE
Temporary fix for #301

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -385,6 +385,7 @@ class {$newClassName} {$extends}
         }
 
         $returnHint = '';
+	$attributes = '';
         $nullReturn = 'null';
         $resultReturn = '$__PHAKE_result';
         if ($method->hasReturnType())
@@ -399,10 +400,15 @@ class {$newClassName} {$extends}
                 $resultReturn = '';
             }
         }
+	elseif (PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 90000 && $method->isInternal())
+	{
+	    $attributes = '#[\ReturnTypeWillChange]';
+	}
 
         $docComment = $method->getDocComment() ?: '';
         $methodDef = "
 	{$docComment}
+	{$attributes}
 	{$modifiers} function {$reference}{$method->getName()}({$this->generateMethodParameters($method)}){$returnHint}
 	{
 		\$__PHAKE_args = array();

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -385,7 +385,7 @@ class {$newClassName} {$extends}
         }
 
         $returnHint = '';
-	$attributes = '';
+        $attributes = '';
         $nullReturn = 'null';
         $resultReturn = '$__PHAKE_result';
         if ($method->hasReturnType())
@@ -400,10 +400,10 @@ class {$newClassName} {$extends}
                 $resultReturn = '';
             }
         }
-	elseif (PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 90000 && $method->isInternal())
-	{
-	    $attributes = '#[\ReturnTypeWillChange]';
-	}
+        elseif (PHP_VERSION_ID >= 80100 && PHP_VERSION_ID < 90000 && $method->isInternal())
+        {
+            $attributes = '#[\ReturnTypeWillChange]';
+        }
 
         $docComment = $method->getDocComment() ?: '';
         $methodDef = "


### PR DESCRIPTION
Like I said in #301 this is only a temporary fix to avoid the deprecation error. The real work to do to prepare PHP 9.0 correctly is to infer the good return type, which is not OK with interfaces currently.