### PR TITLE
Add support for PHP8.1 pure intersection types and never return type

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -388,13 +388,18 @@ class {$newClassName} {$extends}
         $attributes = '';
         $nullReturn = 'null';
         $resultReturn = '$__PHAKE_result';
+        $return = 'return ';
         if ($method->hasReturnType())
         {
             $returnType = $method->getReturnType();
             $returnTypeName = $this->implementType($returnType, $method->getDeclaringClass());
             $returnHint = ': ' . $returnTypeName;
 
-            if ($returnTypeName == 'void')
+            if (PHP_VERSION_ID >= 80100 && $returnTypeName == 'never') {
+                $nullReturn = '';
+                $resultReturn = '';
+                $return = "throw new \Phake\Exception\NeverReturnMethodCalledException()";
+            } elseif ($returnTypeName == 'void')
             {
                 $nullReturn = '';
                 $resultReturn = '';
@@ -416,7 +421,7 @@ class {$newClassName} {$extends}
 
         \$__PHAKE_info = Phake::getInfo({$context});
 		if (\$__PHAKE_info === null) {
-		    return {$nullReturn};
+		    ${return}{$nullReturn};
 		}
 
 		\$__PHAKE_funcArgs = array_map(function (\$x) { return \$x; }, \$__PHAKE_args);
@@ -433,7 +438,7 @@ class {$newClassName} {$extends}
     	    \$__PHAKE_result = call_user_func_array(\$__PHAKE_callback, \$__PHAKE_args);
 	    }
 	    \$__PHAKE_answer->processAnswer(\$__PHAKE_result);
-	    return {$resultReturn};
+	    ${return}{$resultReturn};
 	}
 ";
 

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -540,6 +540,8 @@ class {$newClassName} {$extends}
                 $types[] = 'null';
             }
             $result = implode('|', $types);
+        } elseif ($type instanceof \ReflectionIntersectionType) {
+            $result = (string) $type;
         }
 
         return $nullable . $result;

--- a/src/Phake/Exception/NeverReturnMethodCalledException.php
+++ b/src/Phake/Exception/NeverReturnMethodCalledException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phake\Exception;
+
+/**
+ * Thrown when a never return method is called
+ */
+class NeverReturnMethodCalledException extends \Exception
+{
+}

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -66,39 +66,43 @@ class SmartDefaultAnswer implements \Phake\Stubber\IAnswer
         if ($method->hasReturnType())
         {
             $returnType = $method->getReturnType();
-            $typeNames = $returnType instanceof \ReflectionNamedType ? [ $returnType->getName() ] : array_map(function($t) { return $t->getName(); }, $returnType->getTypes());
-            foreach ($typeNames as $typeName) {
-                switch ($typeName)
-                {
-                    case 'int':
-                        $defaultAnswer = 0;
-                        break 2;
-                    case 'float':
-                        $defaultAnswer = 0.0;
-                        break 2;
-                    case 'string':
-                        $defaultAnswer = "";
-                        break 2;
-                    case 'bool':
-                    case 'false':
-                        $defaultAnswer = false;
-                        break 2;
-                    case 'array':
-                        $defaultAnswer = array();
-                        break 2;
-                    case 'callable':
-                        $defaultAnswer = function () {};
-                        break 2;
-                    case 'self':
-                        $defaultAnswer = \Phake::mock($method->getDeclaringClass()->getName());
-                        break 2;
-                    default:
-                        if (class_exists($typeName))
-                        {
-                            $defaultAnswer = \Phake::mock($typeName);
+            if ($returnType instanceof \ReflectionIntersectionType) {
+                $defaultAnswer = \Phake::mock(array_map(function($t) { return $t->getName(); }, $returnType->getTypes()));
+            } else {
+                $typeNames = $returnType instanceof \ReflectionNamedType ? [ $returnType->getName() ] : array_map(function($t) { return $t->getName(); }, $returnType->getTypes());
+                foreach ($typeNames as $typeName) {
+                    switch ($typeName)
+                    {
+                        case 'int':
+                            $defaultAnswer = 0;
                             break 2;
-                        }
-                        break;
+                        case 'float':
+                            $defaultAnswer = 0.0;
+                            break 2;
+                        case 'string':
+                            $defaultAnswer = "";
+                            break 2;
+                        case 'bool':
+                        case 'false':
+                            $defaultAnswer = false;
+                            break 2;
+                        case 'array':
+                            $defaultAnswer = array();
+                            break 2;
+                        case 'callable':
+                            $defaultAnswer = function () {};
+                            break 2;
+                        case 'self':
+                            $defaultAnswer = \Phake::mock($method->getDeclaringClass()->getName());
+                            break 2;
+                        default:
+                            if (class_exists($typeName))
+                            {
+                                $defaultAnswer = \Phake::mock($typeName);
+                                break 2;
+                            }
+                            break;
+                    }
                 }
             }
         }

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -1012,4 +1012,12 @@ class MockClassTest extends TestCase
             $this->fail('Expected stubbing return ArrayObject');
         }
     }
+
+    public function testStubbingNeverReturnType()
+    {
+        if (version_compare(phpversion(), '8.1.0') < 0) {
+            $this->markTestSkipped('never type is not supported in PHP versions prior to 8.1');
+        }
+        $this->assertInstanceOf('PhakeTest_NeverReturn', Phake::mock('PhakeTest_NeverReturn'));
+    }
 }

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -987,4 +987,29 @@ class MockClassTest extends TestCase
             $this->fail('Expected stubbing return self');
         }
     }
+
+    public function testStubbingIntersectionTypes()
+    {
+        if (version_compare(phpversion(), '8.1.0') < 0) {
+            $this->markTestSkipped('Intersection types are not supported in PHP versions prior to 8.1');
+        }
+        $this->assertInstanceOf('PhakeTest_IntersectionTypes', Phake::mock('PhakeTest_IntersectionTypes'));
+    }
+
+    public function testStubbingIntersectionReturnType()
+    {
+        if (version_compare(phpversion(), '8.1.0') < 0) {
+            $this->markTestSkipped('Intersection types are not supported in PHP versions prior to 8.1');
+        }
+
+        $mock = Phake::mock('PhakeTest_IntersectionTypes');
+        $expectedResult = new \ArrayObject();
+        Phake::when($mock)->intersectionReturn()->thenReturn($expectedResult);
+
+        try {
+            $this->assertSame($expectedResult, $mock->intersectionReturn());
+        } catch (\TypeError $e) {
+            $this->fail('Expected stubbing return ArrayObject');
+        }
+    }
 }

--- a/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
@@ -116,6 +116,20 @@ class SmartDefaultAnswerTest extends TestCase
         $this->assertTrue(in_array($cb(), [0, '']));
     }
 
+    public function testIntersectionTypeReturn()
+    {
+        if (version_compare(phpversion(), '8.1.0') < 0) {
+            $this->markTestSkipped('Intersection types are not supported in PHP versions prior to 8.1');
+        }
+
+        $context = new \PhakeTest_IntersectionTypes();
+        $cb = $this->answer->getAnswerCallback($context, 'intersectionReturn');
+
+        $result = $cb();
+        $this->assertInstanceOf(\ArrayAccess::class, $result);
+        $this->assertInstanceOf(\Countable::class, $result);
+    }
+
     public function testSelfReturn()
     {
         $context = new \PhakeTest_ScalarTypes();

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1748,6 +1748,31 @@ class PhakeTest extends TestCase
         $this->assertEquals('Asked', $val);
     }
 
+    public function testCallingNeverReturnMockedMethodThrowsNeverReturnMethodCalledException() {
+        if (version_compare(phpversion(), '8.1.0') < 0) {
+            $this->markTestSkipped('never type is not supported in PHP versions prior to 8.1');
+        }
+
+        $this->expectException(Phake\Exception\NeverReturnMethodCalledException::class);
+
+        $mock = Phake::mock(\PhakeTest_NeverReturn::class);
+        $mock->neverReturn();
+    }
+
+    public function testCallingNeverReturnMockedMethodWithThenThrows() {
+        if (version_compare(phpversion(), '8.1.0') < 0) {
+            $this->markTestSkipped('never type is not supported in PHP versions prior to 8.1');
+        }
+
+        $mock = Phake::mock(\PhakeTest_NeverReturn::class);
+        Phake::when($mock)->neverReturn()->thenThrow($expectedException = new \RuntimeException());
+        try {
+            $mock->neverReturn();
+        } catch (\Exception $e) {
+            $this->assertSame($expectedException, $e);
+        }
+    }
+
     /**
      * For #239
      */

--- a/tests/PhakeTest/IntersectionTypes.php
+++ b/tests/PhakeTest/IntersectionTypes.php
@@ -1,0 +1,12 @@
+<?php
+
+class PhakeTest_IntersectionTypes
+{
+    public function intersectionParam(Countable & ArrayAccess $param) {
+
+    }
+
+    public function intersectionReturn(): Countable & ArrayAccess {
+
+    }
+}

--- a/tests/PhakeTest/NeverReturn.php
+++ b/tests/PhakeTest/NeverReturn.php
@@ -1,0 +1,9 @@
+<?php
+
+class PhakeTest_NeverReturn
+{
+    public function neverReturn(): never
+    {
+        die('Asta la vista baby');
+    }
+}

--- a/tests/PhakeTest/SerializableClass.php
+++ b/tests/PhakeTest/SerializableClass.php
@@ -1,16 +1,32 @@
 <?php
 
+if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
 
-class PhakeTest_SerializableClass implements \Serializable
-{
-    public function serialize()
+    class PhakeTest_SerializableClass implements \Serializable
     {
+        public function serialize()
+        {
 
+        }
+
+        public function unserialize($serialized)
+        {
+
+        }
     }
 
-    public function unserialize($serialized)
+} else {
+
+    class PhakeTest_SerializableClass
     {
+        public function __serialize()
+        {
 
+        }
+
+        public function __unserialize($serialized)
+        {
+
+        }
     }
-
-} 
+}


### PR DESCRIPTION
It's now possible to mock class that use pure intersection types :

```
interface Foo {
    public function bar(ArrayAccess & Countable $baz): ArrayAccess & Countable;
}

$mock = Phake::mock(Foo::class);
$result = $mock->bar(new ArrayObject);
var_dump($result instanceof Countable); // true
var_dump($result instanceof ArrayAccess); // true
```

And also never return type

```
class Foo {
    public function foo(): never
    {
    }
}
try {
    $mock = Phake::mock(Foo::class);
    $mock->foo();
} catch (\Exception $e) {
    var_dump(get_class($e)); // Phake\Exception\NeverReturnMethodCalledException
}

```
