### PR TITLE
Fix #209 - Handle static:: calls for static methods in partial mocks

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -113,7 +113,9 @@ class Phake
             $className,
             self::getMockClassGenerator(),
             new \Phake\CallRecorder\Recorder(),
-            $answer
+            $answer,
+            new \Phake\Stubber\Answers\NoAnswer(),
+            true
         );
     }
 
@@ -129,12 +131,15 @@ class Phake
     public static function partialMock($className, ...$args)
     {
         $answer = new \Phake\Stubber\Answers\ParentDelegate();
+        $staticAnswer = new \Phake\Stubber\Answers\ParentDelegate();
 
         return self::getPhake()->mock(
             $className,
             self::getMockClassGenerator(),
             new \Phake\CallRecorder\Recorder(),
             $answer,
+            $staticAnswer,
+            false,
             $args
         );
     }

--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -82,8 +82,12 @@ class MockClass
 
      * @return NULL
      */
-    public function generate($newClassName, $mockedClassName, \Phake\Mock\InfoRegistry $infoRegistry)
-    {
+    public function generate(
+        $newClassName,
+        $mockedClassName,
+        \Phake\Mock\InfoRegistry $infoRegistry,
+        \Phake\Stubber\IAnswer $defaultStaticAnswer = null
+    ) {
         $extends    = '';
         $implements = '';
         $interfaces = array();
@@ -176,7 +180,8 @@ class {$newClassName} {$extends}
 ";
 
         $this->loadClass($newClassName, $mockedClassName, $classDef);
-        $newClassName::$__PHAKE_staticInfo = $this->createMockInfo($mockedClassName, new \Phake\CallRecorder\Recorder(), new \Phake\Stubber\StubMapper(), new \Phake\Stubber\Answers\NoAnswer());
+        $newClassName::$__PHAKE_staticInfo = $this->createMockInfo($mockedClassName, new \Phake\CallRecorder\Recorder(),
+            new \Phake\Stubber\StubMapper(), $defaultStaticAnswer !== null ? $defaultStaticAnswer : new \Phake\Stubber\Answers\NoAnswer());
         $infoRegistry->addInfo($newClassName::$__PHAKE_staticInfo);
     }
 

--- a/tests/Phake/FacadeTest.php
+++ b/tests/Phake/FacadeTest.php
@@ -95,7 +95,9 @@ class FacadeTest extends TestCase
             $mockedClass,
             $mockGenerator,
             $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock(),
-            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock()
+            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+            true
         );
     }
 
@@ -113,7 +115,9 @@ class FacadeTest extends TestCase
             $mockedClass,
             $mockGenerator,
             $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock(),
-            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock()
+            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+            true
         );
     }
 
@@ -130,7 +134,9 @@ class FacadeTest extends TestCase
             $mockedClass,
             $this->getMockBuilder(Phake\ClassGenerator\MockClass::class)->getMock(),
             $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock(),
-            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock()
+            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+            $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+            true
         );
     }
 
@@ -144,11 +150,12 @@ class FacadeTest extends TestCase
         $recorder       = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $classGenerator = $this->getMockBuilder(Phake\ClassGenerator\MockClass::class)->getMock();
         $answer         = $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock();
+        $staticAnswer   = $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock();
 
 
         $this->setMockInstantiatorExpectations($classGenerator, $recorder, $answer);
 
-        $this->facade->mock($mockedClass, $classGenerator, $recorder, $answer);
+        $this->facade->mock($mockedClass, $classGenerator, $recorder, $answer, $staticAnswer, true);
     }
 
     /**
@@ -170,7 +177,9 @@ class FacadeTest extends TestCase
                 $mockedClass,
                 $mockGenerator,
                 $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock(),
-                $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock()
+                $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+                $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock(),
+                false
             );
 
             spl_autoload_unregister(array(__CLASS__, 'autoload'));

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1785,4 +1785,38 @@ class PhakeTest extends TestCase
         $this->assertEquals(42, $mock->foo());
         $this->assertNull($mock->foo());
     }
+
+    public function testCachingOfMockDoesntAffectPartialMock()
+    {
+        Phake::mock(\PhakeTest_ClassWithStaticMethodCalledWithStatic::class);
+        $partialMock = Phake::partialMock(\PhakeTest_ClassWithStaticMethodCalledWithStatic::class);
+
+        $this->assertSame("hello", $partialMock->callingStaticWithStaticAccessor());
+    }
+
+    public function testPartialMockStubsStaticMethodsWithCallParent()
+    {
+        $partialMock = Phake::partialMock(\PhakeTest_ClassWithStaticMethodCalledWithStatic::class);
+
+        $this->assertSame("hello", $partialMock->callingStaticWithStaticAccessor());
+    }
+
+    public function testPartialMockThenCallParentWorks()
+    {
+        $partialMock = Phake::partialMock(\PhakeTest_ClassWithStaticMethodCalledWithStatic::class);
+        Phake::whenStatic($partialMock)->staticMethod->thenCallParent();
+
+        $this->assertSame("hello", $partialMock->callingStaticWithStaticAccessor());
+    }
+
+    public function testPartialMocksDontShareStubs()
+    {
+        $partialMock1 = Phake::partialMock(\PhakeTest_ClassWithStaticMethodCalledWithStatic::class);
+        Phake::whenStatic($partialMock1)->staticMethod->thenCallParent();
+        $partialMock2 = Phake::partialMock(\PhakeTest_ClassWithStaticMethodCalledWithStatic::class);
+        Phake::whenStatic($partialMock2)->staticMethod->thenReturn("world");
+
+        $this->assertSame("hello", $partialMock1->callingStaticWithStaticAccessor());
+        $this->assertSame("world", $partialMock2->callingStaticWithStaticAccessor());
+    }
 }

--- a/tests/PhakeTest/ClassWithStaticMethodCalledWithStatic.php
+++ b/tests/PhakeTest/ClassWithStaticMethodCalledWithStatic.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2021, Mike Lively <m@digitalsandwich.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+class PhakeTest_ClassWithStaticMethodCalledWithStatic {
+    public static function staticMethod(): string
+    {
+        return "hello";
+    }
+
+    public function callingStaticWithStaticAccessor(): string
+    {
+        return static::staticMethod();
+    }
+}


### PR DESCRIPTION
An attempt do deal with mocking static methods in partial mocks so static:: access to the methods works.