### PR TITLE
Use ReflectionType::__toString() for PHP 7.0 instead of ReflectionNamedType::getName()

### DIFF
--- a/src/Phake/ClassGenerator/MockClass.php
+++ b/src/Phake/ClassGenerator/MockClass.php
@@ -417,7 +417,7 @@ class {$newClassName} {$extends}
         if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
         {
             $returnType = $method->getReturnType();
-            $returnTypeName = $returnType->getName();
+            $returnTypeName = Phake_Reflection_ReflectionUtils::getTypeName($returnType);
 
             if ($returnTypeName == 'self')
             {
@@ -547,7 +547,7 @@ class {$newClassName} {$extends}
                 $type = $parameter->getClass()->getName() . ' ';
             } elseif (method_exists($parameter, 'hasType') && $parameter->hasType())
             {
-                $type = $parameter->getType()->getName() . ' ';
+                $type = Phake_Reflection_ReflectionUtils::getTypeName($parameter->getType()) . ' ';
             }
 
             if (method_exists($parameter, 'hasType') && $parameter->hasType() && $parameter->allowsNull()) {

--- a/src/Phake/Reflection/ReflectionUtils.php
+++ b/src/Phake/Reflection/ReflectionUtils.php
@@ -1,0 +1,14 @@
+<?php
+
+class Phake_Reflection_ReflectionUtils
+{
+    public static function getTypeName(\ReflectionType $type): string
+    {
+        if (version_compare(phpversion(), '7.1.0') < 0) {
+            return (string)$type;
+        } else {
+            /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+            return $type->getName();
+        }
+    }
+}

--- a/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
+++ b/src/Phake/Stubber/Answers/SmartDefaultAnswer.php
@@ -63,7 +63,8 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
 
         if (method_exists($method, 'hasReturnType') && $method->hasReturnType())
         {
-            switch ($method->getReturnType()->getName())
+            $returnType = Phake_Reflection_ReflectionUtils::getTypeName($method->getReturnType());
+            switch ($returnType)
             {
                 case 'int':
                     $defaultAnswer = 0;
@@ -84,9 +85,9 @@ class Phake_Stubber_Answers_SmartDefaultAnswer implements Phake_Stubber_IAnswer
                     $defaultAnswer = function () {};
                     break;
                 default:
-                    if (class_exists($method->getReturnType()->getName()))
+                    if (class_exists($returnType))
                     {
-                        $defaultAnswer = Phake::mock($method->getReturnType()->getName());
+                        $defaultAnswer = Phake::mock($returnType);
                     }
                     break;
             }


### PR DESCRIPTION
This PR fixes a bug when using Phake 3.1.9 with PHP 7.0 to mock classes which include parameter type hints or return type hints.

Doing so currently causes an error, because Phake calls [ReflectionNamedType::getName](https://www.php.net/manual/en/reflectionnamedtype.getname.php), which only exists in PHP >=7.1. Since composer.json only requires PHP >=7, I'm assuming this isn't intentional.

The change to use getName was introduced in 0c47b06b, apparently to prevent PHPUnit from throwing deprecation errors (because [ReflectionType::__toString](https://www.php.net/manual/en/reflectiontype.tostring.php) was deprecated in PHP 7.1), so it doesn't seem correct to simply revert that change. Instead, I've introduced a util class that calls either `__toString()` or `getName()` depending on the PHP version.

Hopefully this should work for everyone!