### PR TITLE
WIP - Store mock info outside of the object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Remove deprecated `AnswerProxyInterface::thenGetReturnByLambda()`
 - `Phake::verifyNoOtherInteractions()` is now variadic
 - Private methods will not be mocked anymore (there is no point to it).
+- Readonly classes are now mockable

--- a/src/Phake.php
+++ b/src/Phake.php
@@ -603,15 +603,8 @@ class Phake
     public static function getInfo(Phake\IMock|string $mock): Phake\Mock\Info
     {
         static::assertValidMock($mock);
-        if ($mock instanceof Phake\IMock) {
-            assert(isset($mock->__PHAKE_info));
 
-            return $mock->__PHAKE_info;
-        }
-
-        assert(isset($mock::$__PHAKE_staticInfo));
-
-        return $mock::$__PHAKE_staticInfo;
+        return self::getPhake()->getInfo($mock);
     }
 
     /**

--- a/src/Phake/Facade.php
+++ b/src/Phake/Facade.php
@@ -97,11 +97,25 @@ class Facade
 
         return $mockGenerator->instantiate(
             $this->cachedClasses[implode('__', $mockedClassList)],
+            $this->infoRegistry,
             $callRecorder,
             new Stubber\StubMapper(),
             $defaultAnswer,
             $constructorArgs
         );
+    }
+
+    /**
+     * @param class-string|\Phake\IMock $mock
+     */
+    public function getInfo(\Phake\IMock|string $mock): Mock\Info
+    {
+        return $this->infoRegistry->getInfo($mock);
+    }
+
+    public function getInfoRegistry(): Mock\InfoRegistry
+    {
+        return $this->infoRegistry;
     }
 
     public function resetStaticInfo(): void

--- a/src/Phake/Mock/InfoRegistry.php
+++ b/src/Phake/Mock/InfoRegistry.php
@@ -46,6 +46,8 @@ declare(strict_types=1);
 
 namespace Phake\Mock;
 
+use WeakMap;
+
 /**
  * Stores all Info instances for static classes.
  */
@@ -54,17 +56,44 @@ class InfoRegistry
     /**
      * @var array<Info>
      */
-    private array $registry = [];
+    private array $staticRegistry = [];
 
-    public function addInfo(Info $info): void
+    private WeakMap $registry;
+
+    public function __construct()
     {
-        $this->registry[] = $info;
+        $this->registry = new WeakMap();
+    }
+
+    /**
+     * @param \Phake\IMock|class-string $mock
+     */
+    public function addInfo(\Phake\IMock|string $mock, Info $info): void
+    {
+        if ($mock instanceof \Phake\IMock) {
+            $this->registry[$mock] = $info;
+            return;
+        }
+
+        $this->staticRegistry[$mock] = $info;
+    }
+
+    /**
+     * @param \Phake\IMock|class-string $mock
+     */
+    public function getInfo(\Phake\IMock|string $mock): ?Info
+    {
+        if ($mock instanceof \Phake\IMock) {
+            return $this->registry[$mock] ?? null;
+        }
+
+        return $this->staticRegistry[$mock] ?? null;
     }
 
     public function resetAll(): void
     {
         /* @var $info Info */
-        foreach ($this->registry as $info) {
+        foreach ($this->staticRegistry as $info) {
             $info->resetInfo();
         }
     }

--- a/tests/Phake/ClassGenerator/MockClassTest.php
+++ b/tests/Phake/ClassGenerator/MockClassTest.php
@@ -64,7 +64,8 @@ class MockClassTest extends TestCase
     public function setUp(): void
     {
         Phake::initAnnotations($this);
-        $this->classGen = new MockClass();
+        $this->classGen = Phake::getMockClassGenerator();
+        $this->infoRegistry = Phake::getPhake()->getInfoRegistry();
     }
 
     /**
@@ -119,7 +120,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock();
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $this->assertSame($callRecorder, Phake::getInfo($mock)->getCallRecorder());
     }
@@ -137,7 +138,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = new Phake\Stubber\Answers\NoAnswer();
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         /* @var $callRecorder Phake\CallRecorder\Recorder */
         $callRecorder->expects($this->once())
@@ -160,7 +161,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = new Phake\Stubber\Answers\NoAnswer();
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         /* @var $callRecorder Phake\CallRecorder\Recorder */
         $callRecorder->expects($this->once())
@@ -243,7 +244,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = Phake::mock(Phake\Stubber\Answers\NoAnswer::class, Phake::ifUnstubbed()->thenCallParent());
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $this->assertInstanceOf($newClassName, $mock);
     }
@@ -262,7 +263,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = Phake::partialMock(Phake\Stubber\Answers\NoAnswer::class);
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $stubMapper->expects($this->once())
             ->method('getStubByCall')
@@ -287,7 +288,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = Phake::partialMock(Phake\Stubber\Answers\NoAnswer::class);
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $stubMapper->expects($this->once())
             ->method('getStubByCall')
@@ -315,7 +316,7 @@ class MockClassTest extends TestCase
         /** @var $stubMapper Phake\Stubber\StubMapper */
         $stubMapper = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer     = $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock();
-        $mock       = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock       = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $answer           = $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock();
         $answerCollection = new Phake\Stubber\AnswerCollection($answer);
@@ -344,7 +345,7 @@ class MockClassTest extends TestCase
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = Phake::partialMock(Phake\Stubber\Answers\NoAnswer::class);
 
-        $mock = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $mock->fooWithArgument('bar');
 
@@ -365,7 +366,7 @@ class MockClassTest extends TestCase
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = Phake::partialMock(Phake\Stubber\Answers\NoAnswer::class);
 
-        $mock = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $mock->fooWithArgument('bar');
 
@@ -382,7 +383,7 @@ class MockClassTest extends TestCase
         $callRecorder = Phake::mock(Phake\CallRecorder\Recorder::class);
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = Phake::partialMock(Phake\Stubber\Answers\NoAnswer::class);
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $mock->foo('blah');
 
@@ -404,7 +405,7 @@ class MockClassTest extends TestCase
         $callRecorder = Phake::mock(Phake\CallRecorder\Recorder::class);
         $stubMapper   = Phake::mock(Phake\Stubber\StubMapper::class);
         $answer       = Phake::partialMock(Phake\Stubber\Answers\NoAnswer::class);
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
         Phake::when($stubMapper)->getStubByCall->thenReturn(null);
 
         $mock->foo('blah');
@@ -442,7 +443,7 @@ class MockClassTest extends TestCase
         $callRecorder = $this->getMockBuilder(Phake\CallRecorder\Recorder::class)->getMock();
         $stubMapper   = $this->getMockBuilder(Phake\Stubber\StubMapper::class)->getMock();
         $answer       = $this->getMockBuilder(Phake\Stubber\IAnswer::class)->getMock();
-        $mock         = $this->classGen->instantiate($newClassName, $callRecorder, $stubMapper, $answer);
+        $mock         = $this->classGen->instantiate($newClassName, $this->infoRegistry, $callRecorder, $stubMapper, $answer);
 
         $this->assertEquals(\PhakeTest_MockedClass::class, $mock::__PHAKE_name);
         $this->assertEquals(\PhakeTest_MockedClass::class, Phake::getInfo($mock)->getName());
@@ -464,6 +465,7 @@ class MockClassTest extends TestCase
         $answer     = new Phake\Stubber\Answers\ParentDelegate();
         $mock       = $this->classGen->instantiate(
             $newClassName,
+            $this->infoRegistry,
             $callRecorder,
             $stubMapper,
             $answer,
@@ -491,6 +493,7 @@ class MockClassTest extends TestCase
         $answer     = new Phake\Stubber\Answers\ParentDelegate();
         $mock       = $this->classGen->instantiate(
             $newClassName,
+            $this->infoRegistry,
             $callRecorder,
             $stubMapper,
             $answer,
@@ -562,7 +565,7 @@ class MockClassTest extends TestCase
         $mapper   = new Phake\Stubber\StubMapper();
         $answer   = new Phake\Stubber\Answers\ParentDelegate();
 
-        $mock = $this->classGen->instantiate($newClassName, $recorder, $mapper, $answer);
+        $mock = $this->classGen->instantiate($newClassName, $this->infoRegistry, $recorder, $mapper, $answer);
 
         $string = $mock->__toString();
 
@@ -581,7 +584,7 @@ class MockClassTest extends TestCase
         $mapper   = new Phake\Stubber\StubMapper();
         $answer   = new Phake\Stubber\Answers\ParentDelegate();
 
-        $mock = $this->classGen->instantiate($newClassName, $recorder, $mapper, $answer);
+        $mock = $this->classGen->instantiate($newClassName, $this->infoRegistry, $recorder, $mapper, $answer);
 
         \PhakeTest_DestructorClass::$destructCalled = false;
         unset($mock);
@@ -600,7 +603,7 @@ class MockClassTest extends TestCase
         $answer   = new Phake\Stubber\Answers\ParentDelegate();
 
         try {
-            $mock = $this->classGen->instantiate($newClassName, $recorder, $mapper, $answer);
+            $mock = $this->classGen->instantiate($newClassName, $this->infoRegistry, $recorder, $mapper, $answer);
             $this->assertInstanceOf(\PhakeTest_SerializableClass::class, $mock);
         } catch (\Exception $e) {
             $this->fail("Can't instantiate Serializable Object");
@@ -641,7 +644,7 @@ class MockClassTest extends TestCase
         $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
 
         /* @var $info Phake\Mock\Info */
-        $info = $newClassName::$__PHAKE_staticInfo;
+        $info = $this->infoRegistry->getInfo($newClassName);
         $this->assertInstanceOf(Phake\Mock\Info::class, $info);
 
         $this->assertInstanceOf(Phake\Stubber\IAnswer::class, $info->getDefaultAnswer());
@@ -657,7 +660,7 @@ class MockClassTest extends TestCase
         $mockedClass  = \stdClass::class;
         $this->classGen->generate($newClassName, $mockedClass, $this->infoRegistry);
 
-        Phake::verify($this->infoRegistry)->addInfo($newClassName::$__PHAKE_staticInfo);
+        $this->assertInstanceOf(Phake\Mock\Info::class, $this->infoRegistry->getInfo($newClassName));
     }
 
     /**
@@ -1003,13 +1006,10 @@ class MockClassTest extends TestCase
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Readonly classes are not supported in PHP versions prior to 8.2');
         }
-        $expectedException = new \InvalidArgumentException('Readonly classes cannot be mocked.');
 
-        try {
-            $mock = Phake::mock(\PhakeTest_ReadonlyClass::class);
-            $this->fail('Mocking a readonly class should throw an exception');
-        } catch (\InvalidArgumentException $actualException) {
-            $this->assertEquals($actualException, $expectedException);
-        }
+        $mock = Phake::mock(\PhakeTest_ReadonlyClass::class);
+
+        $this->assertInstanceOf(\PhakeTest_ReadonlyClass::class, $mock);
+        $this->assertInstanceOf(\Phake\IMock::class, $mock);
     }
 }

--- a/tests/Phake/FacadeTest.php
+++ b/tests/Phake/FacadeTest.php
@@ -220,6 +220,7 @@ class FacadeTest extends TestCase
             ->method('instantiate')
             ->with(
                 $this->matchesRegularExpression('#^[A-Za-z0-9_]+$#'),
+                $this->equalTo($this->infoRegistry),
                 $this->equalTo($recorder),
                 $this->isInstanceOf(Phake\Stubber\StubMapper::class),
                 $this->equalTo($answer)

--- a/tests/Phake/Mock/InfoRegistryTest.php
+++ b/tests/Phake/Mock/InfoRegistryTest.php
@@ -37,9 +37,9 @@ class InfoRegistryTest extends TestCase
     {
         Phake::initAnnotations($this);
         $this->registry = new Phake\Mock\InfoRegistry();
-        $this->registry->addInfo($this->info1);
-        $this->registry->addInfo($this->info2);
-        $this->registry->addInfo($this->info3);
+        $this->registry->addInfo('foo', $this->info1);
+        $this->registry->addInfo('bar', $this->info2);
+        $this->registry->addInfo('baz', $this->info3);
     }
 
     public function testReset(): void

--- a/tests/Phake/Proxies/CallStubberProxyTest.php
+++ b/tests/Phake/Proxies/CallStubberProxyTest.php
@@ -63,9 +63,7 @@ class CallStubberProxyTest extends TestCase
     public function setUp(): void
     {
         $this->matcher1 = Phake::mock(Phake\Matchers\IChainableArgumentMatcher::class);
-        $this->obj      = new class implements Phake\IMock {
-            public $__PHAKE_info = null;
-        };
+        $this->obj      = Phake::mock(\stdClass::class);
         \PhakeTestUtil::setStubMapper($this->obj, Phake::mock(Phake\Stubber\StubMapper::class));
         $this->proxy    = new CallStubberProxy($this->matcher1, false);
     }

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1553,7 +1553,7 @@ class PhakeTest extends TestCase
         $chocolateCookie = Phake::mock(\PhakeTest_A::class);
         $berryCookie = Phake::mock(\PhakeTest_A::class);
 
-        $this->assertNotEquals($chocolateCookie, $berryCookie);
+        $this->assertNotSame($chocolateCookie, $berryCookie);
     }
 
     public function testStaticClassesReset(): void


### PR DESCRIPTION
This is an experimental branch to move all mocking storage (`Mock\Info` objects) out of the mock object. This will make it possible to mock `readonly` objects.

