### PR TITLE
Provide a better type-hint for mock and partial mock objects

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -99,10 +99,12 @@ class Phake
     /**
      * Returns a new mock object based on the given class name.
      *
-     * @param string|array                    $className
-     * @param \Phake\Stubber\IAnswerContainer $defaultAnswer
+     * @phpstan-template T of object
      *
-     * @return mixed
+     * @param class-string<T>|array<class-string<T>> $className
+     * @param \Phake\Stubber\IAnswerContainer        $defaultAnswer
+     *
+     * @return \Phake\IMock&T
      */
     public static function mock($className, \Phake\Stubber\IAnswerContainer $defaultAnswer = null)
     {
@@ -128,9 +130,10 @@ class Phake
      *
      * Calls to this class will be recorded however they will still call the original functionality by default.
      *
-     * @param string $className class name
+     * @phpstan-template T of object
+     * @param class-string<T> $className class name
      * @param mixed ...$args the remaining arguments will be passed as constructor arguments
-     * @return \Phake\IMock
+     * @return \Phake\IMock&T
      */
     public static function partialMock($className, ...$args)
     {
@@ -149,9 +152,10 @@ class Phake
      * For backwards compatibility
      *
      * @see Phake::partialMock()
-     * @param string $className class name
+     * @phpstan-template T of object
+     * @param class-string<T> $className class name
      * @param mixed ...$args The remaining arguments will be passed as constructor arguments
-     * @return \Phake\IMock
+     * @return \Phake\IMock&T
      * @deprecated Please use Phake::partialMock() instead
      */
     public static function partMock($className, ...$args)


### PR DESCRIPTION
When using Phake to create a mock, the mock object returned is declared by the PHPDoc as `mixed`, which causes issue in static-analysis tools like PHPStan or Psalm when using the mock object.

What is hard here is that the mock object is a `\Phake\IMock` object but also shares its definition with the class/interface(s) we are mocking.

After[ a little help asked on PHPStan project](https://phpstan.org/r/f06ef7e7-6d54-4734-b45e-a05bd50adc09), I finally came to a solution I tested on my side which works.
With this new type-hints, neither PHPStan nor Psalm complains anymore.

Would it be OK this way?
Thanks a lot.