### PR TITLE
Make `verifyNoOtherInteractions` a variadic method

### DIFF
--- a/src/Phake.php
+++ b/src/Phake.php
@@ -301,18 +301,20 @@ class Phake
      * Allows for verifying that no other interaction occurred with a mock object outside of what has already been
      * verified
      *
-     * @param \Phake\IMock $mock
+     * @param \Phake\IMock ...$mocks
      * @return void
      */
-    public static function verifyNoOtherInteractions(\Phake\IMock $mock)
+    public static function verifyNoOtherInteractions(\Phake\IMock ...$mocks)
     {
-        $callRecorder = Phake::getInfo($mock)->getCallRecorder();
-        $verifier = new \Phake\CallRecorder\Verifier($callRecorder, $mock);
-        self::getClient()->processVerifierResult($verifier->verifyNoOtherCalls());
+        foreach ($mocks as $mock) {
+            $callRecorder = Phake::getInfo($mock)->getCallRecorder();
+            $verifier = new \Phake\CallRecorder\Verifier($callRecorder, $mock);
+            self::getClient()->processVerifierResult($verifier->verifyNoOtherCalls());
 
-        $sCallRecorder = Phake::getInfo(get_class($mock))->getCallRecorder();
-        $sVerifier = new \Phake\CallRecorder\Verifier($sCallRecorder, get_class($mock));
-        self::getClient()->processVerifierResult($sVerifier->verifyNoOtherCalls());
+            $sCallRecorder = Phake::getInfo(get_class($mock))->getCallRecorder();
+            $sVerifier = new \Phake\CallRecorder\Verifier($sCallRecorder, get_class($mock));
+            self::getClient()->processVerifierResult($sVerifier->verifyNoOtherCalls());
+        }
     }
 
     /**

--- a/tests/PhakeTest.php
+++ b/tests/PhakeTest.php
@@ -1652,6 +1652,36 @@ class PhakeTest extends TestCase
         Phake::verifyNoOtherInteractions($mock);
     }
 
+    public function testVariadicVerifyNoOtherInteractions()
+    {
+        $mocks = [Phake::mock('PhakeTest_MockedInterface'), Phake::mock('PhakeTest_MockedClass')];
+        $mocks[0]->foo('a');
+        $mocks[0]->foo('b');
+        $mocks[1]->foo('z');
+        $mocks[1]->foo('y');
+
+        Phake::verify($mocks[0])->foo('a');
+        Phake::verify($mocks[1])->foo('y');
+        $this->expectException(\Phake\Exception\VerificationException::class);
+        Phake::setClient(Phake::CLIENT_DEFAULT);
+        Phake::verifyNoOtherInteractions(...$mocks);
+    }
+
+    public function testVariadicVerifyNoOtherInteractionsWorks()
+    {
+        $mocks = [Phake::mock('PhakeTest_MockedInterface'), Phake::mock('PhakeTest_MockedClass')];
+        $mocks[0]->foo('a');
+        $mocks[0]->foo('b');
+        $mocks[1]->foo('z');
+        $mocks[1]->foo('y');
+
+        Phake::verify($mocks[0])->foo('a');
+        Phake::verify($mocks[0])->foo('b');
+        Phake::verify($mocks[1])->foo('z');
+        Phake::verify($mocks[1])->foo('y');
+        Phake::verifyNoOtherInteractions(...$mocks);
+    }
+
     public function testCallingProtectedMethods()
     {
         $mock = Phake::mock('PhakeTest_MockedClass');


### PR DESCRIPTION
Currently, `Phake::verifyNoInteraction` and `Phake::verifyNoFurtherInteraction` are variadic methods which can then take 0 to N mocks to check. The very similar method `Phake::verifyNoOtherInteractions` wasn't variadic, which creates a confusion on developer side when using Phake library.

In order to make a more homogeneous API of Phake, I propose to make `Phake::verifyNoOtherInteractions` variadic too, like its siblings.



