### PR TITLE
Add compatibility with PHPUnit12 for PHP 8.3 (from v4.5).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,9 @@ jobs:
           - php: 8.3
             phpunit: ^11.0
             phpunit_config_file: 'phpunit10.xml.dist'
+          - php: 8.4
+            phpunit: ^12.0
+            phpunit_config_file: 'phpunit10.xml.dist'
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "sebastian/comparator": "^1.1|^2.0|^3.0|^4.0|^5.0|^6.0",
+        "sebastian/comparator": "^1.1|^2.0|^3.0|^4.0|^5.0|^6.0|7.0",
         "doctrine/instantiator": "^1.4"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13",
-        "phpunit/phpunit": "^6.5|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^6.5|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "hamcrest/hamcrest-php": "^1.1|^2.0",
         "psalm/phar": "^4.18"
     },

--- a/src/Phake.php
+++ b/src/Phake.php
@@ -95,6 +95,7 @@ class Phake
     public const CLIENT_PHPUNIT9 = 'PHPUNIT9';
     public const CLIENT_PHPUNIT10 = 'PHPUNIT10';
     public const CLIENT_PHPUNIT11 = 'PHPUNIT11';
+    public const CLIENT_PHPUNIT12 = 'PHPUNIT12';
 
     /**
      * Returns a new mock object based on the given class name.
@@ -600,7 +601,9 @@ class Phake
     {
         if (!isset(self::$client)) {
             if (class_exists(\PHPUnit\Framework\TestCase::class)) {
-                if (version_compare(\PHPUnit\Runner\Version::id(), '11.0.0') >= 0) {
+                if (version_compare(\PHPUnit\Runner\Version::id(), '12.0.0') >= 0) {
+                    return self::$client = new \Phake\Client\PHPUnit12();
+                } elseif (version_compare(\PHPUnit\Runner\Version::id(), '11.0.0') >= 0) {
                     return self::$client = new \Phake\Client\PHPUnit11();
                 } elseif (version_compare(\PHPUnit\Runner\Version::id(), '10.0.0') >= 0) {
                     return self::$client = new \Phake\Client\PHPUnit10();
@@ -643,6 +646,8 @@ class Phake
             self::$client = new \Phake\Client\PHPUnit10();
         } elseif (self::CLIENT_PHPUNIT11 == $client) {
             self::$client = new \Phake\Client\PHPUnit11();
+        } elseif (self::CLIENT_PHPUNIT12 == $client) {
+            self::$client = new \Phake\Client\PHPUnit12();
         } else {
             self::$client = new \Phake\Client\DefaultClient();
         }

--- a/src/Phake/Client/PHPUnit12.php
+++ b/src/Phake/Client/PHPUnit12.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phake\Client;
+
+/*
+ * Phake - Mocking Framework
+ *
+ * Copyright (c) 2010-2022, Mike Lively <mike.lively@sellingsource.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *  *  Neither the name of Mike Lively nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   Testing
+ * @package    Phake
+ * @author     Mike Lively <m@digitalsandwich.com>
+ * @copyright  2010 Mike Lively <m@digitalsandwich.com>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.digitalsandwich.com/
+ */
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * The client adapter used for PHPUnit.
+ *
+ * This adapter allows PHPUnit to report failed verify() calls as test failures instead of errors. It also counts
+ * verify() calls as assertions.
+ */
+class PHPUnit12 implements IClient
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function processVerifierResult(\Phake\CallRecorder\VerifierResult $result)
+    {
+        Assert::assertThat($result, $this->getConstraint());
+
+        return $result->getMatchedCalls();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function processObjectFreeze()
+    {
+        Assert::assertThat(true, Assert::isTrue());
+    }
+
+    /**
+     * @return \Phake\PHPUnit\VerifierResultConstraintV6
+     */
+    private function getConstraint()
+    {
+        return new \Phake\PHPUnit\VerifierResultConstraintV6();
+    }
+}

--- a/tests/Phake/Client/PHPUnitXTest.php
+++ b/tests/Phake/Client/PHPUnitXTest.php
@@ -55,7 +55,11 @@ class Phake_Client_PHPUnitXTest extends TestCase
 
     public function setUp(): void
     {
-        if (version_compare(\PHPUnit\Runner\Version::id(), '10.0.0') >= 0) {
+        if (version_compare(\PHPUnit\Runner\Version::id(), '12.0.0') >= 0) {
+            $this->client = new Phake\Client\PHPUnit12();
+        } elseif (version_compare(\PHPUnit\Runner\Version::id(), '11.0.0') >= 0) {
+            $this->client = new Phake\Client\PHPUnit11();
+        } elseif (version_compare(\PHPUnit\Runner\Version::id(), '10.0.0') >= 0) {
             $this->client = new Phake\Client\PHPUnit10();
         } elseif (version_compare(\PHPUnit\Runner\Version::id(), '9.0.0') >= 0) {
             $this->client = new Phake\Client\PHPUnit9();


### PR DESCRIPTION
This PR is the same as #326 but from base branch 4.5 in order to stay in major version 4.