### PR TITLE
Missing allowance of sebastian/comparator 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "sebastian/comparator": "^1.1|^2.0|^3.0|^4.0|^5.0|^6.0|7.0",
+        "sebastian/comparator": "^1.1|^2.0|^3.0|^4.0|^5.0|^6.0|^7.0",
         "doctrine/instantiator": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
This is a bugfix because otherwise, you wouldn't be allowed to require sebastian/comparator with 7.x, only 7.0.0.

Sebastian Bergmann released a patch as 7.0.1 for PHPUnit 12.0.7 last friday, and Phake enters in conflict because of this typo. 

Otherwise, maybe you should consider #326 :wink: 