### PR TITLE
Fix `SmartDefaultAnswerTest::testCallableReturn()`

### DIFF
--- a/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
+++ b/tests/Phake/Stubber/Answers/SmartDefaultAnswerTest.php
@@ -93,8 +93,7 @@ class SmartDefaultAnswerTest extends TestCase
         $context = new \PhakeTest_ScalarTypes();
         $cb = $this->answer->getAnswerCallback($context, 'callableReturn');
 
-        $this->assertEquals(function () {
-        }, $cb());
+        $this->assertInstanceOf(\Closure::class, $cb());
     }
 
     public function testObjectReturn()


### PR DESCRIPTION
Closures cannot be meaningfully compared for equality. Test for `instanceof Closure` instead.

see sebastianbergmann/comparator#129